### PR TITLE
Added sinusoidal ramping for the turn inputs in usercontrol.cpp

### DIFF
--- a/Caldwell-2020-Code/src/usercontrol.cpp
+++ b/Caldwell-2020-Code/src/usercontrol.cpp
@@ -9,6 +9,11 @@ void toggleAutoSorter(void) {
   else {method=AUTO;}
 }
 
+double sinusoidal(double input) {
+  return \
+  (-50*cos((pi*input)/(100))+50)*(input/(fabs(input)));
+}
+
 void usercontrol(void) {
   float throttle;
   float strafe;
@@ -19,7 +24,7 @@ void usercontrol(void) {
 
     throttle = con.Axis3.value();
     strafe = con.Axis4.value();
-    turn = con.Axis1.value();
+    turn = sinusoidal(con.Axis1.value());
 
     LF.spin(directionType::fwd, (throttle+strafe+turn), velocityUnits::pct);
     LB.spin(directionType::fwd, (throttle-strafe+turn), velocityUnits::pct);


### PR DESCRIPTION
Ben mentioned that turning the robot was a bit hard due to the speediness of the drive, so I ramped the turn command so that it is sinusoidal in shape instead of linear. The curve I used is shown in the picture; it is drawn in red, whereas the regular y=x line is drawn in purple.

![image](https://user-images.githubusercontent.com/66532042/94979593-3b142880-04e9-11eb-9868-c612f555578d.png)
[x-axis: controller input. y-axis: motor command]

I think this will give a really nice balance between speed and fine control; once Ben has tested it, if it's good, I'll merge it.
