### PR TITLE
Added the ability to open/close intakes partway

### DIFF
--- a/Caldwell-2020-Code/src/usercontrol.cpp
+++ b/Caldwell-2020-Code/src/usercontrol.cpp
@@ -49,6 +49,8 @@ void openIntakesUSR() {
 
 void stopOpeningIntakes() {
   intakesOpening = false;
+  IntakeL.stop(hold);
+  IntakeR.stop(hold);
 }
 
 void usercontrol(void) {
@@ -73,7 +75,7 @@ void usercontrol(void) {
     //Intakes
     con.ButtonR1.pressed(spinIntakes);
     con.ButtonR1.released(stopIntakes);
-    con.ButtonR2.pressed(openIntakesWide);
+    con.ButtonR2.pressed(openIntakesUSR);
     con.ButtonR2.released(stopOpeningIntakes);
     
     //Switching Roller Control Methods


### PR DESCRIPTION
Hey, this should allow the intakes to be opened/closed partway during matches rather than fully open or fully closed. If whoever has the robot could test/provide feedback, that would be great.